### PR TITLE
correcting error msg in gcc 9.4 due goto label withou code

### DIFF
--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -3830,7 +3830,7 @@ void rtw_disassoc_cmd_callback(_adapter*	padapter,  struct cmd_obj *pcmd)
 	rtw_free_cmd_obj(pcmd);
 	
 exit:
-	
+     return;
 }
 
 

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -141,6 +141,7 @@ void _rtw_free_mlme_priv (struct mlme_priv *pmlmepriv)
 		}
 	}
 exit:
+    return;
 }
 
 sint	_rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
@@ -158,7 +159,7 @@ sint	_rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
 	_exit_critical_bh(&queue->lock, &irqL);
 
 exit:	
-
+   
 
 	return _SUCCESS;
 }
@@ -266,7 +267,7 @@ void _rtw_free_network(struct	mlme_priv *pmlmepriv ,struct wlan_network *pnetwor
 	_exit_critical_bh(&free_queue->lock, &irqL);
 	
 exit:		
-	
+     return;	
 
 }
 
@@ -293,7 +294,7 @@ void _rtw_free_network_nolock(struct	mlme_priv *pmlmepriv, struct wlan_network *
 	//_exit_critical(&free_queue->lock, &irqL);
 	
 exit:		
-
+     return;
 
 }
 
@@ -2141,7 +2142,7 @@ void rtw_stassoc_event_callback(_adapter *adapter, u8 *pbuf)
 	
 	
 exit:
-	
+      return;	
 
 }
 

--- a/core/rtw_security.c
+++ b/core/rtw_security.c
@@ -203,7 +203,8 @@ static void crc32_init(void)
 		}
 		bcrc32initialized= 1;
 	}
-exit:	
+exit:
+     return;	
 }
 
 static u32 getcrc32(u8 *buf, sint len)

--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -811,7 +811,7 @@ void rtw_free_all_stainfo(_adapter *padapter)
 	}
 
 exit:
-
+     return;
 
 }
 

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -393,7 +393,7 @@ void _rtw_free_xmit_priv (struct xmit_priv *pxmitpriv)
 	rtw_free_hwxmits(padapter);
 
 out:	
-
+       return;
 
 }
 

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -289,7 +289,7 @@ void rtw_report_sec_ie(_adapter *adapter,u8 authmode,u8 *sec_ie)
 	}
 
 exit:
-
+       return;
 
 }
 

--- a/os_dep/linux/usb_ops_linux.c
+++ b/os_dep/linux/usb_ops_linux.c
@@ -972,7 +972,7 @@ void usb_read_port_complete(struct urb *purb, struct pt_regs *regs)
 	}	
 
 exit:	
-	
+      return;	
 	
 }
 


### PR DESCRIPTION
While compiling i was getting a error message

/tmp/lps/rtl8188fu/core/rtw_cmd.c:3832:1: error: label at end of compound statement
 3832 | exit:
      | ^~~~

probably due compiler options. I did correct the code where there was goto label without code line.

gcc version 9.4.0 (Ubuntu 9.4.0-1ubuntu1~20.04.1)

